### PR TITLE
Let assertEquals be strict assertSame

### DIFF
--- a/tests/CountryListTest.php
+++ b/tests/CountryListTest.php
@@ -14,7 +14,7 @@ class CountryListTest extends TestCase
         $this->assertIsArray($countryList);
 
         $this->assertArrayHasKey('GB', $countryList);
-        $this->assertEquals('United Kingdom', $countryList['GB']);
+        $this->assertSame('United Kingdom', $countryList['GB']);
     }
 
     public function testCountryListInheriting(): void
@@ -24,10 +24,10 @@ class CountryListTest extends TestCase
         $this->assertIsArray($countryList);
 
         $this->assertArrayHasKey('TA', $countryList);
-        $this->assertEquals('Tristán da Cunha', $countryList['TA']);
+        $this->assertSame('Tristán da Cunha', $countryList['TA']);
 
         $this->assertArrayHasKey('GB', $countryList);
-        $this->assertEquals('Reino Unido', $countryList['GB']);
+        $this->assertSame('Reino Unido', $countryList['GB']);
     }
 
     public function testCountryListForInvalidLocale(): void

--- a/tests/DataBuilderTest.php
+++ b/tests/DataBuilderTest.php
@@ -45,7 +45,7 @@ class DataBuilderTest extends TestCase
         $this->assertFileExists($versionFile);
         $version = require $versionFile;
 
-        $this->assertEquals('1', $version);
+        $this->assertSame('1', $version);
 
         return $outputDir;
     }
@@ -63,10 +63,10 @@ class DataBuilderTest extends TestCase
         $data = require $englishFile;
 
         $this->assertArrayHasKey('MFC', $data);
-        $this->assertEquals('My First Country', $data['MFC']);
+        $this->assertSame('My First Country', $data['MFC']);
 
         $this->assertArrayHasKey('MSC', $data);
-        $this->assertEquals('My Second Country', $data['MSC']);
+        $this->assertSame('My Second Country', $data['MSC']);
 
         $this->assertArrayNotHasKey('EU', $data, 'EU is part of the ignored region list, so should be ignored');
         $this->assertArrayNotHasKey('GB-alt-short', $data, 'GB-alt-short is an alternative name, so should be ignored');
@@ -89,7 +89,7 @@ class DataBuilderTest extends TestCase
         $this->assertArrayNotHasKey('MFC', $data);
 
         $this->assertArrayHasKey('MSC', $data);
-        $this->assertEquals('My Second Country is different here', $data['MSC']);
+        $this->assertSame('My Second Country is different here', $data['MSC']);
     }
 
     /**

--- a/tests/DisplayRegionTest.php
+++ b/tests/DisplayRegionTest.php
@@ -15,7 +15,7 @@ class DisplayRegionTest extends TestCase
      */
     public function testGetDisplayRegion(string $locale, string $inLocale, string $expectedRegion): void
     {
-        $this->assertEquals(
+        $this->assertSame(
             $expectedRegion,
             Locale::getDisplayRegion($locale, $inLocale),
             "getDisplayRegion with $locale and $inLocale"

--- a/tests/PrimaryLanguageTest.php
+++ b/tests/PrimaryLanguageTest.php
@@ -14,7 +14,7 @@ class PrimaryLanguageTest extends TestCase
      */
     public function testGetPrimaryLanguage(string $locale, string $language): void
     {
-        $this->assertEquals($language, Locale::getPrimaryLanguage($locale));
+        $this->assertSame($language, Locale::getPrimaryLanguage($locale));
     }
 
     /**
@@ -249,7 +249,7 @@ class PrimaryLanguageTest extends TestCase
      */
     public function testUnderscoreOrDash(string $locale, string $language): void
     {
-        $this->assertEquals($language, Locale::getPrimaryLanguage($locale));
+        $this->assertSame($language, Locale::getPrimaryLanguage($locale));
     }
 
     /**

--- a/tests/RegionTest.php
+++ b/tests/RegionTest.php
@@ -14,7 +14,7 @@ class RegionTest extends TestCase
      */
     public function testGetRegion(string $locale, string $expectedRegion): void
     {
-        $this->assertEquals($expectedRegion, Locale::getRegion($locale));
+        $this->assertSame($expectedRegion, Locale::getRegion($locale));
     }
 
     /**

--- a/tests/VersionTest.php
+++ b/tests/VersionTest.php
@@ -26,6 +26,6 @@ class VersionTest extends TestCase
         }
 
         $this->assertNotNull($version);
-        $this->assertEquals($version, Locale::getVersion());
+        $this->assertSame($version, Locale::getVersion());
     }
 }


### PR DESCRIPTION
# Changed log

- Let assertEquals be strict assertSame and it can avoid ambiguous assertions.